### PR TITLE
Add GOPATH ENV

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM scratch
 
+ENV GOPATH=/app
+
 COPY dockerui /
 COPY dist /
 


### PR DESCRIPTION
I had to add the GOPATH env variable to build the image succesfully as I was getting the following error during docker build:
dockerui.go:17:5: cannot find package "authui" in any of:
    /usr/local/go/src/pkg/authui (from $GOROOT)
    /go/src/authui (from $GOPATH)
